### PR TITLE
removing deprecated pledge

### DIFF
--- a/common/sys_serenity.c
+++ b/common/sys_serenity.c
@@ -318,7 +318,7 @@ Sys_MakeCodeWriteable(void *start_addr, void *end_addr)
 int
 main(int argc, const char *argv[])
 {
-    if (pledge("stdio thread unix shared_buffer rpath wpath cpath fattr sigaction", NULL) < 0) {
+    if (pledge("stdio thread unix recvfd sendfd rpath wpath cpath fattr sigaction", NULL) < 0) {
         perror("pledge");
         return 1;
     }
@@ -373,7 +373,7 @@ main(int argc, const char *argv[])
     Host_Init(&parms);
 #endif /* SERVERONLY */
 
-    if (pledge("stdio thread shared_buffer rpath wpath cpath", NULL) < 0) {
+    if (pledge("stdio thread recvfd sendfd rpath wpath cpath", NULL) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
Recently the "shared_buffer" pledge was removed, so the pledge call failed.
This commit fixed it for me.

I found the git history of the pledge manpage useful for fixing.
https://github.com/SerenityOS/serenity/commits/master/Base/usr/share/man/man2/pledge.md

best regards.