### PR TITLE
Common: Patch out `glEnable(GL_VERTEX_ARRAY)`

### DIFF
--- a/common/developer.c
+++ b/common/developer.c
@@ -223,7 +223,6 @@ DbgPanel_Draw(debug_panel_t *panel)
     glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
 
     GL_Bind(glpic->texnum);
-    glEnable(GL_VERTEX_ARRAY);
     glEnableClientState(GL_VERTEX_ARRAY);
     glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
@@ -259,7 +258,6 @@ DbgPanel_Draw(debug_panel_t *panel)
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-    glDisable(GL_VERTEX_ARRAY);
 
     if (panel->alpha < 1.0f) {
         glDisable(GL_BLEND);

--- a/common/gl_rmain.c
+++ b/common/gl_rmain.c
@@ -832,8 +832,6 @@ R_AliasDrawModel(entity_t *entity)
     glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
 
     /* Draw */
-    glEnable(GL_VERTEX_ARRAY);
-
     if (gl_mtexable)
         qglClientActiveTexture(GL_TEXTURE0);
 
@@ -901,7 +899,6 @@ R_AliasDrawModel(entity_t *entity)
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-    glDisable(GL_VERTEX_ARRAY);
 
     c_alias_polys += aliashdr->numtris;
 

--- a/common/gl_rsurf.c
+++ b/common/gl_rsurf.c
@@ -1442,7 +1442,6 @@ DrawSolidChain(triangle_buffer_t *buffer, msurface_t *surf, glbrushmodel_t *glbr
 static void
 GL_BeginMaterialChains()
 {
-    glEnable(GL_VERTEX_ARRAY);
     glEnableClientState(GL_VERTEX_ARRAY);
     if (gl_mtexable) {
 	qglClientActiveTexture(GL_TEXTURE0);
@@ -1468,7 +1467,6 @@ GL_EndMaterialChains()
 
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-    glDisable(GL_VERTEX_ARRAY);
 }
 
 static void

--- a/common/r_part.c
+++ b/common/r_part.c
@@ -821,7 +821,6 @@ R_DrawParticles(void)
     glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
     glDepthMask(GL_FALSE);
 
-    glEnable(GL_VERTEX_ARRAY);
     glEnableClientState(GL_VERTEX_ARRAY);
     glEnableClientState(GL_TEXTURE_COORD_ARRAY);
     glEnableClientState(GL_COLOR_ARRAY);
@@ -840,7 +839,6 @@ R_DrawParticles(void)
     if (particle)
         goto addParticle;
 
-    glDisable(GL_VERTEX_ARRAY);
     glDisableClientState(GL_VERTEX_ARRAY);
     glDisableClientState(GL_TEXTURE_COORD_ARRAY);
     glDisableClientState(GL_COLOR_ARRAY);


### PR DESCRIPTION
Calling `glEnable` with `GL_VERTEX_ARRAY` as an argument is invalid; it can only be used with `glEnableClientState`. This prevents spamming the debug log when developing with `GL_DEBUG` enabled.