### PR TITLE
Startup: Pledge prot_exec during initialization

### DIFF
--- a/common/sys_serenity.c
+++ b/common/sys_serenity.c
@@ -318,7 +318,7 @@ Sys_MakeCodeWriteable(void *start_addr, void *end_addr)
 int
 main(int argc, const char *argv[])
 {
-    if (pledge("stdio thread unix recvfd sendfd rpath wpath cpath fattr sigaction", NULL) < 0) {
+    if (pledge("stdio thread unix recvfd sendfd rpath wpath cpath fattr sigaction prot_exec", NULL) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
This is needed since we now load the LibGL GPU backend dynamically which
requires allocating new executable memory pages.

After initialization is done the pledge can be removed again.