### PR TITLE
Startup: Add the `proc` pledge to support thread priorities

### DIFF
--- a/common/sys_serenity.c
+++ b/common/sys_serenity.c
@@ -318,7 +318,7 @@ Sys_MakeCodeWriteable(void *start_addr, void *end_addr)
 int
 main(int argc, const char *argv[])
 {
-    if (pledge("stdio thread unix recvfd sendfd rpath wpath cpath fattr sigaction prot_exec", NULL) < 0) {
+    if (pledge("stdio thread unix recvfd sendfd rpath wpath cpath fattr sigaction prot_exec proc", NULL) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
On initialization, SDL tries to set the audio thread's priority. This short-lived `proc` pledge allows for that.