### PR TITLE
Startup: Add `map_fixed` pledge

### DIFF
--- a/common/sys_serenity.c
+++ b/common/sys_serenity.c
@@ -318,7 +318,7 @@ Sys_MakeCodeWriteable(void *start_addr, void *end_addr)
 int
 main(int argc, const char *argv[])
 {
-    if (pledge("stdio thread unix recvfd sendfd rpath wpath cpath fattr sigaction prot_exec proc", NULL) < 0) {
+    if (pledge("stdio thread unix recvfd sendfd rpath wpath cpath fattr sigaction prot_exec map_fixed proc", NULL) < 0) {
         perror("pledge");
         return 1;
     }


### PR DESCRIPTION
This pledge is now checked when dynamically loading a library.